### PR TITLE
Fix playback toggling after hiding sections

### DIFF
--- a/src/lib/components/DaisyPlayer/DaisyPlayer.tsx
+++ b/src/lib/components/DaisyPlayer/DaisyPlayer.tsx
@@ -62,6 +62,7 @@ const DaisyPlayer: React.FC<ComponentProps> = ({
       }
     } else if (currentView === "playerView" && wasPlayingBeforeSwitch && !playing) {
       togglePlayPause();
+      setWasPlayingBeforeSwitch(false);
     }
   }, [currentView, playing, togglePlayPause, wasPlayingBeforeSwitch]);
 


### PR DESCRIPTION
## Summary
- ensure `wasPlayingBeforeSwitch` resets after returning to the player view

## Testing
- `npm run build` *(fails: Cannot find module 'react')*