### PR TITLE
Add focus-aware keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ The DAISY Player requires a backend server that hosts DAISY format books with th
 - **I**: Toggle section list view
 - **Escape**: Close section list view (when open)
 
+Keyboard shortcuts are only active when the player container (or any of its
+controls) has keyboard focus. Use the **Tab** key or click on the player to
+focus it before using these shortcuts.
+
 ## Accessibility
 
 This player is designed with accessibility as a primary concern:

--- a/src/lib/components/AccessibleAudioPlayer/AccessibleAudioPlayer.tsx
+++ b/src/lib/components/AccessibleAudioPlayer/AccessibleAudioPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { FaPlay, FaPause, FaStepBackward, FaStepForward, FaPlus, FaMinus } from 'react-icons/fa';
 import { TbReload } from 'react-icons/tb';
 import { createTranslator } from '../../utils/i18n';
@@ -32,6 +32,7 @@ const AccessibleAudioPlayer: React.FC<ComponentProps> = ({
   language = 'en'
 }) => {
   const t = createTranslator(language);
+  const playerRef = useRef<HTMLDivElement>(null);
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
@@ -40,7 +41,7 @@ const AccessibleAudioPlayer: React.FC<ComponentProps> = ({
     setProgress((currentTime / audio.duration) * 100 || 0);
   }, [currentTime, audioRef]);
 
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!isDisplayed) return;
     switch (event.key) {
       case 'k':
@@ -67,14 +68,8 @@ const AccessibleAudioPlayer: React.FC<ComponentProps> = ({
         setPlaybackRate(playbackRate - 0.1);
         break;
     }
-  }, [isDisplayed, setPlaybackRate, moveHeadAcrossBy, togglePlayPause]);
+  }, [isDisplayed, setPlaybackRate, moveHeadAcrossBy, togglePlayPause, playbackRate]);
 
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [handleKeyDown]);
 
   useEffect(() => {
     if (!isDisplayed) return;
@@ -84,7 +79,14 @@ const AccessibleAudioPlayer: React.FC<ComponentProps> = ({
   }, [isDisplayed]);
 
   return (
-    <div className="AudioPlayer" role="region" aria-label={t('audioPlayer')}>
+    <div
+      className="AudioPlayer"
+      role="region"
+      aria-label={t('audioPlayer')}
+      ref={playerRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <audio ref={audioRef} aria-label={title} preload="metadata" className="AudioPlayer__Audio" />
       <h2 className="AudioPlayer__Title">{title}</h2>
       <div className="AudioPlayer__Controls">

--- a/src/lib/components/DaisyPlayer/DaisyPlayer.tsx
+++ b/src/lib/components/DaisyPlayer/DaisyPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import useSectionsAudioPlayer from '../../hooks/useSectionsAudioPlayer';
 import SectionList from '../SectionList/SectionList';
 import useSectionData from '../../hooks/useSectionData';
@@ -25,6 +25,7 @@ const DaisyPlayer: React.FC<ComponentProps> = ({
   language = 'en'
 }) => {
   const t = createTranslator(language);
+  const containerRef = useRef<HTMLDivElement>(null);
   const { sectionsHolder, bookInfo } = useSectionData(dirUrl);
   const {
     audioRef,
@@ -77,7 +78,7 @@ const DaisyPlayer: React.FC<ComponentProps> = ({
 
   const playerKeyBindingsPrevented = currentView !== "playerView";
 
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     switch (event.key) {
       case 'i':
         event.preventDefault();
@@ -93,15 +94,14 @@ const DaisyPlayer: React.FC<ComponentProps> = ({
     }
   }, [toggleView, playerKeyBindingsPrevented]);
 
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [handleKeyDown]);
 
   return (
-    <div className={`DaisyPlayer__Container ${className}`}>
+    <div
+      className={`DaisyPlayer__Container ${className}`}
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <div className="DaisyPlayer__OtherButtons">
         <ShareLinkButton
           dirUrl={appUrl}


### PR DESCRIPTION
## Summary
- focusable player container for keyboard shortcuts
- focusable DaisyPlayer container for custom keys
- document that shortcuts only work when player is focused

## Testing
- `npm run build` *(fails: Cannot find module 'react')*