### PR TITLE
Improve screen reader order of player controls

### DIFF
--- a/src/lib/components/AccessibleAudioPlayer/AccessibleAudioPlayer.tsx
+++ b/src/lib/components/AccessibleAudioPlayer/AccessibleAudioPlayer.tsx
@@ -90,46 +90,48 @@ const AccessibleAudioPlayer: React.FC<ComponentProps> = ({
       <audio ref={audioRef} aria-label={title} preload="metadata" className="AudioPlayer__Audio" />
       <h2 className="AudioPlayer__Title">{title}</h2>
       <div className="AudioPlayer__Controls">
-        <div className="AudioPlayer__ControlsRow">
-          <button
-            className="AudioPlayer__Control"
-            onClick={() => moveToPrevNextSection("prev")}
-            aria-label={t('previousSection')}
-          >
-            <FaStepBackward />
-          </button>
-          <button
-            className="AudioPlayer__Control"
-            onClick={() => moveToPrevNextSection("next")}
-            aria-label={t('nextSection')}
-          >
-            <FaStepForward />
-          </button>
-        </div>
-        <div className="AudioPlayer__ControlsRow">
-          <button 
-            className={`AudioPlayer__Control AudioPlayer__Control--play-pause AudioPlayer__Control--${playing ? 'playing' : 'paused'}`}
-            onClick={togglePlayPause}
-            aria-label={playing ? t('pause') : t('play')}
-          >
-            {playing ? <FaPause/> : <FaPlay /> }
-          </button>
-        </div>
-        <div className="AudioPlayer__ControlsRow">
-          <button
-            className="AudioPlayer__Control AudioPlayer__Control--mirrored"
-            onClick={() => moveHeadAcrossBy(-30)}
-            aria-label={t('backward30Seconds')}
-          >
-            <TbReload />
-          </button>
-          <button
-            className="AudioPlayer__Control"
-            onClick={() => moveHeadAcrossBy(30)}
-            aria-label={t('forward30Seconds')}
-          >
-            <TbReload />
-          </button>
+        <div className="AudioPlayer__ControlColumns">
+          <div className="AudioPlayer__ControlsColumn">
+            <button
+              className="AudioPlayer__Control"
+              onClick={() => moveToPrevNextSection("prev")}
+              aria-label={t('previousSection')}
+            >
+              <FaStepBackward />
+            </button>
+            <button
+              className="AudioPlayer__Control AudioPlayer__Control--mirrored"
+              onClick={() => moveHeadAcrossBy(-30)}
+              aria-label={t('backward30Seconds')}
+            >
+              <TbReload />
+            </button>
+          </div>
+          <div className="AudioPlayer__ControlsColumn AudioPlayer__ControlsColumn--play">
+            <button
+              className={`AudioPlayer__Control AudioPlayer__Control--play-pause AudioPlayer__Control--${playing ? 'playing' : 'paused'}`}
+              onClick={togglePlayPause}
+              aria-label={playing ? t('pause') : t('play')}
+            >
+              {playing ? <FaPause/> : <FaPlay /> }
+            </button>
+          </div>
+          <div className="AudioPlayer__ControlsColumn AudioPlayer__ControlsColumn--reverse">
+            <button
+              className="AudioPlayer__Control"
+              onClick={() => moveHeadAcrossBy(30)}
+              aria-label={t('forward30Seconds')}
+            >
+              <TbReload />
+            </button>
+            <button
+              className="AudioPlayer__Control"
+              onClick={() => moveToPrevNextSection("next")}
+              aria-label={t('nextSection')}
+            >
+              <FaStepForward />
+            </button>
+          </div>
         </div>
         <div
           className="AudioPlayer__ControlsRow AudioPlayer__ControlsRow--speed"

--- a/src/lib/components/AccessibleAudioPlayer/index.scss
+++ b/src/lib/components/AccessibleAudioPlayer/index.scss
@@ -25,10 +25,32 @@
   &__Controls {
     width: 100%;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     gap: var(--a11y-player-spacing-sm);
     margin: var(--a11y-player-spacing-sm) 0;
+  }
+
+  &__ControlColumns {
+    display: flex;
+    justify-content: space-evenly;
+    gap: var(--a11y-player-spacing-md);
+    width: 100%;
+  }
+
+  &__ControlsColumn {
+    display: flex;
     flex-direction: column;
+    align-items: center;
+    gap: var(--a11y-player-spacing-md);
+
+    &--play {
+      justify-content: center;
+    }
+
+    &--reverse {
+      flex-direction: column-reverse;
+    }
   }
 
   &__ProgressContainer {


### PR DESCRIPTION
## Summary
- restructure `AccessibleAudioPlayer` controls so DOM order is previous → rewind → play → fast forward → next
- add column-based layout styles to preserve visual arrangement
- center the play button column in the layout

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*