### PR TITLE
Improve mobile responsiveness with rem media queries

### DIFF
--- a/src/lib/components/AccessibleAudioPlayer/index.scss
+++ b/src/lib/components/AccessibleAudioPlayer/index.scss
@@ -38,6 +38,33 @@
     width: 100%;
   }
 
+  @media (max-width: 30rem) {
+    &__ControlColumns {
+      flex-wrap: wrap;
+      gap: var(--a11y-player-spacing-sm);
+    }
+
+    &__ControlsColumn {
+      margin-bottom: var(--a11y-player-spacing-sm);
+    }
+
+    &__Control {
+      font-size: 1.5rem;
+      width: 2rem;
+      height: 2rem;
+
+      &--play-pause {
+        font-size: 2.5rem;
+        width: 3rem;
+        height: 3rem;
+      }
+    }
+
+    &__SpeedText {
+      min-width: 4rem;
+    }
+  }
+
   &__ControlsColumn {
     display: flex;
     flex-direction: column;
@@ -83,7 +110,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 80px;
+    min-width: 5rem;
 
     span {
       font-size: 0.75rem;
@@ -102,16 +129,16 @@
     border-radius: var(--a11y-player-radius-md);
     cursor: pointer;
     font-size: 2rem;
-    width: 40px;
-    height: 40px;
+    width: 2.5rem;
+    height: 2.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
 
     &--play-pause {
       font-size: 3rem;
-      width: 60px;
-      height: 60px;
+      width: 3.75rem;
+      height: 3.75rem;
     }
 
     &--mirrored {
@@ -121,7 +148,7 @@
 
   &__Progress {
     width: 100%;
-    height: 8px;
+    height: 0.5rem;
     appearance: none;
     border-radius: var(--a11y-player-radius-full);
     overflow: hidden;

--- a/src/lib/components/DaisyPlayer/index.scss
+++ b/src/lib/components/DaisyPlayer/index.scss
@@ -63,7 +63,7 @@
   &__Container {
     position: relative;
     width: 100%;
-    max-width: 800px;
+    max-width: 50rem;
     margin: 0 auto;
     padding: var(--a11y-player-spacing-lg);
     background-color: var(--a11y-player-bg-main);
@@ -78,9 +78,14 @@
     border: 1px solid var(--a11y-player-border);
 
     // Responsive adjustments
-    @media (max-width: 768px) {
+    @media (max-width: 48rem) {
       padding: var(--a11y-player-spacing-md);
       border-radius: var(--a11y-player-radius-md);
+    }
+
+    @media (max-width: 30rem) {
+      padding: var(--a11y-player-spacing-sm);
+      border-radius: var(--a11y-player-radius-sm);
     }
 
     // Subtle hover effect for the entire container
@@ -101,8 +106,11 @@
       margin-bottom: var(--a11y-player-spacing-sm);
       color: var(--a11y-player-text-primary);
 
-      @media (max-width: 768px) {
+      @media (max-width: 48rem) {
         font-size: 1.5rem;
+      }
+      @media (max-width: 30rem) {
+        font-size: 1.25rem;
       }
     }
 
@@ -112,9 +120,13 @@
       margin-bottom: var(--a11y-player-spacing-lg);
       color: var(--a11y-player-text-secondary);
 
-      @media (max-width: 768px) {
+      @media (max-width: 48rem) {
         font-size: 1rem;
         margin-bottom: var(--a11y-player-spacing-md);
+      }
+      @media (max-width: 30rem) {
+        font-size: 0.9rem;
+        margin-bottom: var(--a11y-player-spacing-sm);
       }
     }
   }
@@ -202,7 +214,7 @@
   }
 
   &__Progress {
-    height: 8px;
+    height: 0.5rem;
     border-radius: var(--a11y-player-radius-full);
     background-color: var(--a11y-player-progress-bg);
     overflow: hidden;

--- a/src/lib/components/SectionList/index.scss
+++ b/src/lib/components/SectionList/index.scss
@@ -31,19 +31,32 @@
     position: absolute;
     top: var(--a11y-player-spacing-lg);
     right: var(--a11y-player-spacing-lg);
-    width: 40px;
-    height: 40px;
+    width: 2.5rem;
+    height: 2.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
   }
 
+  @media (max-width: 30rem) {
+    &__Container {
+      padding: var(--a11y-player-spacing-md);
+    }
+
+    &__BackArrow {
+      top: var(--a11y-player-spacing-md);
+      right: var(--a11y-player-spacing-md);
+      width: 2rem;
+      height: 2rem;
+    }
+  }
+
   &__List {
     text-align: left;
     margin: var(--a11y-player-spacing-sm) 0;
     width: 100%;
-    max-width: 600px;
+    max-width: 37.5rem;
     padding-left: var(--a11y-player-spacing-md);
 
     &--level0 {


### PR DESCRIPTION
## Summary
- convert control sizes from `px` to `rem`
- add additional responsive breakpoints for very small screens
- adjust overlay padding and button sizes for mobile
- use `rem` based max-width and progress heights

## Testing
- `npm run build` *(fails: JSX intrinsic elements errors)*