### PR TITLE
Adjust layout for responsive full-screen demo

### DIFF
--- a/src/demo/App.css
+++ b/src/demo/App.css
@@ -1,7 +1,6 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100%;
+  height: 100%;
   text-align: center;
 }
 

--- a/src/demo/index.css
+++ b/src/demo/index.css
@@ -22,6 +22,13 @@ a:hover {
   color: #535bf2;
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   margin: 0;
   display: flex;

--- a/src/lib/components/AccessibleAudioPlayer/index.scss
+++ b/src/lib/components/AccessibleAudioPlayer/index.scss
@@ -65,6 +65,19 @@
     }
   }
 
+  @media (max-width: 20rem) {
+    &__ControlColumns {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    &__ControlsColumn {
+      flex-direction: row;
+      justify-content: center;
+      width: 100%;
+    }
+  }
+
   &__ControlsColumn {
     display: flex;
     flex-direction: column;

--- a/src/lib/components/DaisyPlayer/index.scss
+++ b/src/lib/components/DaisyPlayer/index.scss
@@ -63,7 +63,8 @@
   &__Container {
     position: relative;
     width: 100%;
-    max-width: 50rem;
+    max-width: 100%;
+    height: 100%;
     margin: 0 auto;
     padding: var(--a11y-player-spacing-lg);
     background-color: var(--a11y-player-bg-main);


### PR DESCRIPTION
## Summary
- let the Daisy player container use full width and height
- remove demo root max-width to display full screen
- ensure html, body and root elements are 100% size
- stack player control groups vertically on very small screens

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: cannot find type definition file)*
